### PR TITLE
Avoid endless recursion on Windows.

### DIFF
--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -15,13 +15,14 @@ var cache = {};
 // Use a cache of promises for building the directory tree. This allows us to
 // correctly queue up file extractions for after their path has been created,
 // avoid trying to create the path twice and still be async.
+var windowsRoot = /^[A-Z]:\\$/;
 var mkdir = function (dir) {
     dir = path.normalize(path.resolve(process.cwd(), dir) + path.sep);
 
     if (!cache[dir]) {
         var parent;
 
-        if (dir === '/') {
+        if (dir === '/' || (process.platform === 'win32' && dir.match(windowsRoot))) {
             parent = new Q();
         } else {
             parent = mkdir(path.dirname(dir));


### PR DESCRIPTION
`mkdir` did not recognize the root directory on Windows.
