### PR TITLE
Added an extra check for file type. (closes bower/bower#991)

### DIFF
--- a/lib/structures.js
+++ b/lib/structures.js
@@ -165,6 +165,11 @@ var readDirectory = function (buffer) {
             index += current.fileCommentLength;
         }
 
+        if (current.fileAttributes.type !== 'Directory' && current.fileName.substr(-1) === '/') {
+            // TODO: check that this is a reasonable check
+            current.fileAttributes.type = 'Directory';
+        }
+
         directory.push(current);
     }
 


### PR DESCRIPTION
If the file name ends with '/', we treat it as a directory even if the
metadata says it isn't.
