### PR TITLE
Exception when using strip:1

### DIFF
--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -116,7 +116,8 @@ DecompressZip.prototype.extract = function (options) {
                         dir = dir.slice(options.strip);
                     }
 
-                    return file.path = path.join(dir.join(path.sep), filename);
+                    file.path = path.join(dir.join(path.sep), filename);
+                    return file;
                 }
             });
         }


### PR DESCRIPTION
decompress-zip:0.0.6: Extracting a simple zip file with one level of empty directory at the root will throw an TypeError on path.join decompress-zip.js:259 if strip:1 is set

```
DecompressZip.prototype.extractFile = function (file, options) {
var destination = path.join(options.path, file.path);
```

The issue is in decompress-zip.js:109..120, which, instead of adding .path to the file entry, is returning the path directly in files.map().

```
files = files.map(function (file) {
                if (file.type !== 'Directory') {
...
                    return file.path //<-- this is replacing file with file.path in the map.
                    // should be:
                    //   file.path = path.join(dir.join(path.sep), filename);
                    //   return file

                }
```

Note: The current tests do not detect the issue as they do not validate the feature at all - they just test strip to see if an exception is thrown for the 'stripping too deep' case. Ideally, the stripping too deep test case should validate the exact exception expected and a new test case with strip:1 should be added.