### PR TITLE
Large zips throw EMFILE (too many file descriptor) errors

### DIFF
--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -5,7 +5,7 @@
 // assertions everywhere to make sure that we are not dealing with a ZIP type
 // that I haven't designed for. Things like spanning archives, non-DEFLATE
 // compression, encryption, etc.
-var fs = require('fs');
+var fs = require('graceful-fs');
 var Q = require('q');
 var path = require('path');
 var util = require('util');

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -2,7 +2,7 @@ var stream = require('stream');
 if (!stream.Readable) {
     var stream = require('readable-stream');
 }
-var fs = require('fs');
+var fs = require('graceful-fs');
 var Q = require('q');
 var path = require('path');
 var zlib = require('zlib');

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "binary": "~0.3.0",
     "touch": "0.0.2",
     "readable-stream": "~1.1.8",
-    "nopt": "~2.2.0"
+    "nopt": "~2.2.0",
+    "graceful-fs": "~2.0.3"
   }
 }


### PR DESCRIPTION
@wibblymat: This pull request fixes #24 ("Unable to decompress relatively big ZIP on Windows"). I think it will occur on linux/mac systems, not just Windows (though I saw it on Windows as well). In my case, I was working with a 56mb zip with lots of files in it and was consistently getting EMFILE errors.

Switching to https://github.com/isaacs/node-graceful-fs (one of the top 100 depended-on modules in npm) fixed the problem.
