### PR TITLE
Upgrade touch dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "q": "~1.0.0",
     "mkpath": "~0.1.0",
     "binary": "~0.3.0",
-    "touch": "0.0.2",
+    "touch": "0.0.3",
     "readable-stream": "~1.1.8",
     "nopt": "~2.2.0",
     "graceful-fs": "~3.0.0"


### PR DESCRIPTION
The npm registry seems to have problems serving touch#0.0.2 (see https://github.com/npm/npm/issues/5636#issuecomment-49189798), which means that installing bower randomly fails. The v0.0.3 file doesn't seem to have this problem, so upgrade to that version. There is no functional difference between 0.0.2 and 0.0.3.
