### PR TITLE
Fix 2 bugs when strip number > 0

### DIFF
--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -107,7 +107,8 @@ DecompressZip.prototype.extract = function (options) {
         if (options.strip) {
             files = files.map(function (file) {
                 if (file.type !== 'Directory') {
-                    var dir = file.parent.split(path.sep);
+                    //the path sep is '/' in windows which is not equals to path.sep.
+                    var dir = file.parent.split('/');
                     var filename = file.filename;
 
                     if (options.strip > dir.length) {

--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -116,7 +116,8 @@ DecompressZip.prototype.extract = function (options) {
                         dir = dir.slice(options.strip);
                     }
 
-                    return file.path = path.join(dir.join(path.sep), filename);
+                    file.path = path.join(dir.join(path.sep), filename);
+                    return file;
                 }
             });
         }


### PR DESCRIPTION
1) the map function should return file instance;
2) in windows ,the path.sep("\") is not equals to the file seperator("/") in zip entry 