### PR TITLE
Fix shift amounts in structures.js.

### DIFF
--- a/lib/structures.js
+++ b/lib/structures.js
@@ -54,8 +54,8 @@ var parseExternalFileAttributes = function (externalAttributes, platform) {
     case 3: // Unix
         return {
             platform: 'Unix',
-            type: types[(externalAttributes >> 60) & 0x0F],
-            mode: (externalAttributes >> 48) & 0xFFF
+            type: types[(externalAttributes >> 28) & 0x0F],
+            mode: (externalAttributes >> 16) & 0xFFF
         };
 
     // case 0: // MSDOS


### PR DESCRIPTION
As per the ECMA standard (Section 11.7.2), only the least significant five bits of the right operand of a shift operation are taken into account.