### PR TITLE
return a file object instead of the path in case the strip option is used

### DIFF
--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -116,7 +116,8 @@ DecompressZip.prototype.extract = function (options) {
                         dir = dir.slice(options.strip);
                     }
 
-                    return file.path = path.join(dir.join(path.sep), filename);
+                    file.path = path.join(dir.join(path.sep), filename);
+                    return file;
                 }
             });
         }


### PR DESCRIPTION
prevents a call to file.path returns undefined