### PR TITLE
Added progress events, w/ test

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ unzipper.on('extract', function (log) {
 });
 
 unzipper.on('progress', function (fileIndex, fileCount) {
-    console.log('Extracting file ' + (fileIndex + 1) + ' of ' + fileCount);
+    console.log('Extracted file ' + (fileIndex + 1) + ' of ' + fileCount);
 });
 
 unzipper.extract({

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ unzipper.on('extract', function (log) {
     console.log('Finished extracting');
 });
 
+unzipper.on('progress', function (fileIndex, fileCount) {
+    console.log('Extracting file ' + (fileIndex + 1) + ' of ' + fileCount);
+});
+
 unzipper.extract({
     path: 'some/path',
     filter: function (file) {

--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -241,9 +241,10 @@ DecompressZip.prototype.extractFiles = function (files, options, results) {
 
     results = results || [];
 
-    files.forEach(function (file) {
+    files.forEach(function (file, i) {
         var promise = self.extractFile(file, options)
         .then(function (result) {
+            self.emit('progress', i, files.length);
             results.push(result);
         });
 

--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -240,11 +240,11 @@ DecompressZip.prototype.extractFiles = function (files, options, results) {
     var self = this;
 
     results = results || [];
-
-    files.forEach(function (file, i) {
+    var fileIndex = 0;
+    files.forEach(function (file) {
         var promise = self.extractFile(file, options)
         .then(function (result) {
-            self.emit('progress', i, files.length);
+            self.emit('progress', fileIndex++, files.length);
             results.push(result);
         });
 

--- a/test/test.js
+++ b/test/test.js
@@ -71,6 +71,31 @@ describe('Extract', function () {
 
             zip.extract({path: tmpDir, strip: 3});
         });
+
+        it('should emit a progress event on each file', function (done) {
+            var zip = new DecompressZip(path.join(assetsPath, samples[0]));
+            var numProgressEvents = 0;
+            var numTotalFiles = 921;
+
+            zip.on('progress', function (i, numFiles) {
+                assert.equal(numFiles, numTotalFiles, '"progress" event should include the correct number of files');
+                assert(typeof i === 'number', '"progress" event should include the number of the current file');
+                numProgressEvents++;
+            });
+
+            zip.on('extract', function () {
+                assert(true, '"extract" event should fire');
+                assert.equal(numProgressEvents, numTotalFiles, 'there should be a "progress" event for every file');
+                done();
+            });
+
+            zip.on('error', function (error) {
+                assert(false, '"error" event should not fire');
+                done();
+            });
+
+            zip.extract({path: tmpDir});
+        });
     });
 
     samples.forEach(function (sample) {


### PR DESCRIPTION
We needed to give the user progress notifications when extracting large zips, so they don't give up or think it is stuck. It's a small change, but may prove useful for others.

I'm not super-familiar with the codebase or with promises, but I think this should do the trick. I added a test & it passes.

Note that if #37 reduces the number of files in the first test zip file (as requested in https://github.com/bower/decompress-zip/pull/32#issuecomment-55375832 ?), then the `numTotalFiles` variable in the test will need to be adjusted.