### PR TITLE
Fix ENOENT bug by moving dir cache to DecompressZip instance

### DIFF
--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -30,6 +30,7 @@ function DecompressZip(filename) {
     this.stats = null;
     this.fd = null;
     this.chunkSize = 1024 * 1024; // Buffer up to 1Mb at a time
+    this.dirCache = {};
 
     // When we need a resource, we should check if there is a promise for it
     // already and use that. If the promise is already fulfilled we don't do the
@@ -284,7 +285,7 @@ DecompressZip.prototype.extractFile = function (file, options) {
     //   98 - PPMd version I, Rev 1
 
     if (file.type === 'Directory') {
-        return extractors.folder(file, destination);
+        return extractors.folder(file, destination, this);
     }
 
     if (file.type === 'File') {

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -12,12 +12,11 @@ var writeFile = Q.denodeify(fs.writeFile);
 var inflateRaw = Q.denodeify(zlib.inflateRaw);
 var symlink = Q.denodeify(fs.symlink);
 var stat = Q.denodeify(fs.stat);
-var cache = {};
 
 // Use a cache of promises for building the directory tree. This allows us to
 // correctly queue up file extractions for after their path has been created,
 // avoid trying to create the path twice and still be async.
-var mkdir = function (dir) {
+var mkdir = function (dir, cache) {
     dir = path.normalize(path.resolve(process.cwd(), dir) + path.sep);
 
     if (!cache[dir]) {
@@ -26,7 +25,7 @@ var mkdir = function (dir) {
         if (fs.existsSync(dir)) {
             parent = new Q();
         } else {
-            parent = mkdir(path.dirname(dir));
+            parent = mkdir(path.dirname(dir), cache);
         }
 
         cache[dir] = parent.then(function () {
@@ -39,8 +38,8 @@ var mkdir = function (dir) {
 
 // Utility methods for writing output files
 var extractors = {
-    folder: function (folder, destination) {
-        return mkdir(destination)
+    folder: function (folder, destination, zip) {
+        return mkdir(destination, zip.dirCache)
         .then(function () {
             return {folder: folder.path};
         });
@@ -61,7 +60,7 @@ var extractors = {
             writer = pipePromise.bind(null, input, destination);
         }
 
-        return mkdir(path.dirname(destination))
+        return mkdir(path.dirname(destination), zip.dirCache)
         .then(writer)
         .then(function () {
             return {stored: file.path};
@@ -72,7 +71,7 @@ var extractors = {
         // in fact many ZIP files don't include compressed file sizes for
         // Deflated files so we don't even know what the end offset is.
 
-        return mkdir(path.dirname(destination))
+        return mkdir(path.dirname(destination), zip.dirCache)
         .then(function () {
             if (file._maxSize <= zip.chunkSize) {
                 return zip.getBuffer(file._offset, file._offset + file._maxSize)
@@ -97,7 +96,7 @@ var extractors = {
     },
     symlink: function (file, destination, zip, basePath) {
         var parent = path.dirname(destination);
-        return mkdir(parent)
+        return mkdir(parent, zip.dirCache)
         .then(function () {
             return getLinkLocation(file, destination, zip, basePath);
         })
@@ -114,7 +113,7 @@ var extractors = {
         var type;
         var parent = path.dirname(destination);
 
-        return mkdir(parent)
+        return mkdir(parent, zip.dirCache)
         .then(function () {
             return getLinkLocation(file, destination, zip, basePath);
         })
@@ -128,7 +127,7 @@ var extractors = {
                     return pipePromise(input, destination);
                 } else if (stats.isDirectory()) {
                     type = 'Directory';
-                    return mkdir(destination);
+                    return mkdir(destination, zip.dirCache);
                 } else {
                     throw new Error('Could not follow symlink to unknown file type');
                 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-simple-mocha": "~0.4.0",
     "mocha": "~1.13.0",
     "glob": "~3.2.6",
-    "tmp": "0.0.21",
+    "tmp": "0.0.24",
     "request": "~2.27.0"
   },
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -73,6 +73,37 @@ describe('Extract', function () {
         });
     });
 
+    describe('directory creation', function () {
+        var tmpDir, rmdirSync;
+        before(function (done) {
+            tmp.dir({unsafeCleanup: true}, function (err, dir, cleanupCallback) {
+                if (err) {
+                    throw err;
+                }
+
+                tmpDir = dir;
+                rmdirSync = cleanupCallback;
+                done();
+            });
+        });
+        
+        it('should create necessary directories, even on 2nd run', function (done) {
+            var zip = new DecompressZip(path.join(assetsPath, samples[0]));
+            zip.on('error', done);
+            zip.on('extract', function () {
+                rmdirSync(tmpDir);
+                var zip2 = new DecompressZip(path.join(assetsPath, samples[0]));
+                zip2.on('error', done);
+                zip2.on('extract', function () {
+                    done();
+                });
+                zip2.extract({path: tmpDir});
+            });
+            
+            zip.extract({path: tmpDir});
+        });
+    });
+
     samples.forEach(function (sample) {
         var extracted = path.join(path.dirname(sample), 'extracted');
 

--- a/test/test.js
+++ b/test/test.js
@@ -74,7 +74,8 @@ describe('Extract', function () {
     });
 
     describe('directory creation', function () {
-        var tmpDir, rmdirSync;
+        var tmpDir;
+        var rmdirSync;
         before(function (done) {
             tmp.dir({unsafeCleanup: true}, function (err, dir, cleanupCallback) {
                 if (err) {


### PR DESCRIPTION
This is a more robust fix for #29. As explained on that pull request (and demonstrated in the included test), decompress-zip will throw an `ENOENT` if you attempt to unzip a file to a directory, then delete the directory and unzip the file to that directory again. This is due to the directory `cache` living at the module level and not being invalidated between runs.

My previous fix for this (#38) invalidated the cache between runs, but as discussed on that pull request, it wouldn't work well for people using decompress-zip concurrently. This pull request uses the approach suggested by @BCooper63 and seconded by @sindresorhus: moving the cache to the DecompressZip instance, so a new cache is created for each instance.

The code changes are minimal and straightforward. All tests pass, including a new one that covers this issue. @sindresorhus: would you be able to take a quick look?

For my test, I needed to recursively rmdir the temp directory. To do this, I bumped to a newer version of the `tmp` module, which passes a `cleanupCallback` that recursively removes the temp directory.