### PR TITLE
Added option absolute/relative symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Returns an EventEmitter with two possible events - `error` on an error, and `ext
 **Options**
 - **path** *String* - Path to extract into (default `.`)
 - **follow** *Boolean* - If true, rather than create stored symlinks as symlinks make a shallow copy of the target instead (default `false`)
+- **absolute** *Boolean* - If false, all symlinks will be exported the same way they were created, by default aboslut symlinks will be created (default `true`)
 - **filter** *Function* - A function that will be called once for each file in the archive. It takes one argument which is an object containing details of the file. Return true for any file that you want to extract, and false otherwise. (default `null`)
 - **strip** *Number* - Remove leading folders in the path structure. Equivalent to `--strip-components` for tar.
 - **restrict** *Boolean* - If true, will restrict files from being created outside `options.path`. Setting to `false` has significant security [implications](https://snyk.io/research/zip-slip-vulnerability) if you are extracting untrusted data. (default `true`)

--- a/lib/decompress-zip.js
+++ b/lib/decompress-zip.js
@@ -80,6 +80,7 @@ DecompressZip.prototype.extract = function (options) {
     options.path = options.path || process.cwd();
     options.filter = options.filter || null;
     options.follow = !!options.follow;
+    options.absolute = options.absolute !== false;
     options.strip = +options.strip || 0;
     options.restrict = options.restrict !== false;
 
@@ -313,7 +314,7 @@ DecompressZip.prototype.extractFile = function (file, options) {
         if (options.follow) {
             return extractors.copy(file, destination, this, options.path);
         } else {
-            return extractors.symlink(file, destination, this, options.path);
+            return extractors.symlink(file, destination, this, options.path, options.absolute);
         }
     }
 

--- a/lib/extractors.js
+++ b/lib/extractors.js
@@ -99,14 +99,14 @@ var extractors = {
             return {deflated: file.path};
         });
     },
-    symlink: function (file, destination, zip, basePath) {
+    symlink: function (file, destination, zip, basePath, absolute) {
         var parent = path.dirname(destination);
         return mkdir(parent, zip.dirCache)
         .then(function () {
             return getLinkLocation(file, destination, zip, basePath);
         })
         .then(function (linkTo) {
-            return symlink(path.resolve(parent, linkTo), destination)
+            return symlink(absolute? path.resolve(parent, linkTo) : linkTo, destination)
             .then(function () {
                 return {symlink: file.path, linkTo: linkTo};
             });


### PR DESCRIPTION
Sometimes there is a need symlinks to be exactly like they were creating during creation of ZIP file and we don't want symlinks to be absolute always.

I've created option 'absolute' which leaves default behavior by default, but if there is a need someone could pass 'false' and get relative links.

One example where this is needed - decompression of Electron based application update on MacOS. Once we extract .app file we wan't to be able to move it around(Desktop, Applications folder, etc..) and if we have absolute symlinks it won't work. But if we have relative symlinks everything works like a charm.